### PR TITLE
Fixing the jump glitch

### DIFF
--- a/src/main/java/thaumicboots/api/ItemBoots.java
+++ b/src/main/java/thaumicboots/api/ItemBoots.java
@@ -91,6 +91,9 @@ public class ItemBoots extends ItemArmor
     }
 
     public static void setModeJump(ItemStack stack, double state) {
+        if (stack.stackTagCompound == null) {
+            stack.setTagCompound(new NBTTagCompound());
+        }
         stack.stackTagCompound.setDouble(TAG_MODE_JUMP, state);
     }
 
@@ -115,6 +118,9 @@ public class ItemBoots extends ItemArmor
     }
 
     public static void setModeSpeed(ItemStack stack, double state) {
+        if (stack.stackTagCompound == null) {
+            stack.setTagCompound(new NBTTagCompound());
+        }
         stack.stackTagCompound.setDouble(TAG_MODE_SPEED, state);
     }
 

--- a/src/main/java/thaumicboots/api/ItemBoots.java
+++ b/src/main/java/thaumicboots/api/ItemBoots.java
@@ -83,7 +83,11 @@ public class ItemBoots extends ItemArmor
     }
 
     public static double isJumpEnabled(final ItemStack stack) {
-        return stack.stackTagCompound.getDouble(TAG_MODE_JUMP);
+        try {
+            return stack.stackTagCompound.getDouble(TAG_MODE_JUMP);
+        } catch (NullPointerException e) {
+            return 0;
+        }
     }
 
     public static void setModeJump(ItemStack stack, double state) {
@@ -103,7 +107,11 @@ public class ItemBoots extends ItemArmor
     }
 
     public static double isSpeedEnabled(final ItemStack stack) {
-        return stack.stackTagCompound.getDouble(TAG_MODE_SPEED);
+        try {
+            return stack.stackTagCompound.getDouble(TAG_MODE_SPEED);
+        } catch (NullPointerException e) {
+            return 0;
+        }
     }
 
     public static void setModeSpeed(ItemStack stack, double state) {

--- a/src/main/java/thaumicboots/api/ItemBoots.java
+++ b/src/main/java/thaumicboots/api/ItemBoots.java
@@ -83,11 +83,10 @@ public class ItemBoots extends ItemArmor
     }
 
     public static double isJumpEnabled(final ItemStack stack) {
-        try {
-            return stack.stackTagCompound.getDouble(TAG_MODE_JUMP);
-        } catch (NullPointerException e) {
+        if (stack.stackTagCompound == null) {
             return 0;
         }
+        return stack.stackTagCompound.getDouble(TAG_MODE_JUMP);
     }
 
     public static void setModeJump(ItemStack stack, double state) {
@@ -110,11 +109,10 @@ public class ItemBoots extends ItemArmor
     }
 
     public static double isSpeedEnabled(final ItemStack stack) {
-        try {
-            return stack.stackTagCompound.getDouble(TAG_MODE_SPEED);
-        } catch (NullPointerException e) {
+        if (stack.stackTagCompound == null) {
             return 0;
         }
+        return stack.stackTagCompound.getDouble(TAG_MODE_SPEED);
     }
 
     public static void setModeSpeed(ItemStack stack, double state) {

--- a/src/main/java/thaumicboots/events/BootsEventHandler.java
+++ b/src/main/java/thaumicboots/events/BootsEventHandler.java
@@ -85,8 +85,13 @@ public class BootsEventHandler {
         if (item instanceof IMeteor meteor && (player.isSneaking())) {
             meteor.specialEffect2(event);
         } else if (item instanceof ItemBoots boots) {
-            event.entityLiving.motionY += (boots.getJumpModifier()
-                    * ItemBoots.isJumpEnabled(player.inventory.armorItemInSlot(0)));
+            double modifier;
+            try {
+                modifier = ItemBoots.isJumpEnabled(player.inventory.armorItemInSlot(0));
+            } catch (NullPointerException e) {
+                modifier = 1;
+            }
+            event.entityLiving.motionY += (boots.getJumpModifier() * modifier);
         }
         // 0.275D is approx 3 blocks, 0.265D will get you to just 3 blocks,
         // 0.55D is approx 5.5 blocks, so 0.275 is around 2.25 additional blocks

--- a/src/main/java/thaumicboots/events/BootsEventHandler.java
+++ b/src/main/java/thaumicboots/events/BootsEventHandler.java
@@ -85,13 +85,8 @@ public class BootsEventHandler {
         if (item instanceof IMeteor meteor && (player.isSneaking())) {
             meteor.specialEffect2(event);
         } else if (item instanceof ItemBoots boots) {
-            double modifier;
-            try {
-                modifier = ItemBoots.isJumpEnabled(player.inventory.armorItemInSlot(0));
-            } catch (NullPointerException e) {
-                modifier = 1;
-            }
-            event.entityLiving.motionY += (boots.getJumpModifier() * modifier);
+            event.entityLiving.motionY += (boots.getJumpModifier()
+                    * ItemBoots.isJumpEnabled(player.inventory.armorItemInSlot(0)));
         }
         // 0.275D is approx 3 blocks, 0.265D will get you to just 3 blocks,
         // 0.55D is approx 5.5 blocks, so 0.275 is around 2.25 additional blocks


### PR DESCRIPTION
For the moment, this'll just add a catch clause to ensure that the game won't crash if the nbt data somehow doesn't get initialized, fixing the rest now.

Update:
This now has protections to ensure the game won't crash if the nbt data doesn't get initialized (i.e. if the nbt doesn't initialize, you don't crash when you jump) and now has enforcements to initialize the nbt data in-game if it didn't get initialized like it was supposed to.