### PR TITLE
Introduce API functionality for changing speed boosts on EMT traveller boots

### DIFF
--- a/src/main/java/thaumicboots/api/IBoots.java
+++ b/src/main/java/thaumicboots/api/IBoots.java
@@ -1,0 +1,97 @@
+package thaumicboots.api;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+public interface IBoots {
+
+    String TAG_MODE_JUMP = "jump";
+    String TAG_MODE_SPEED = "speed";
+    String TAG_MOD_OMNI = "omni";
+
+    default void setSpeedModifier(ItemStack stack, double modifier) {
+        if (stack.stackTagCompound == null) {
+            stack.setTagCompound(new NBTTagCompound());
+        }
+        stack.stackTagCompound.setDouble(TAG_MODE_SPEED, modifier);
+    }
+
+    default void setJumpModifier(ItemStack stack, double modifier) {
+        if (stack.stackTagCompound == null) {
+            stack.setTagCompound(new NBTTagCompound());
+        }
+        stack.stackTagCompound.setDouble(TAG_MODE_JUMP, modifier);
+    }
+
+    default void setOmniEnabled(ItemStack stack, boolean enabled) {
+        if (stack.stackTagCompound == null) {
+            stack.setTagCompound(new NBTTagCompound());
+        }
+        stack.stackTagCompound.setBoolean(TAG_MOD_OMNI, enabled);
+    }
+
+    default double changeSpeed(ItemStack stack) {
+        if (stack.stackTagCompound == null) {
+            stack.setTagCompound(new NBTTagCompound());
+        }
+        // Internally MC returns 0 by default if the tag is not present, we do not need a presence check.
+        double oldSpeed = stack.stackTagCompound.getDouble(TAG_MODE_SPEED);
+        double newSpeed = oldSpeed + 0.1;
+        if (newSpeed > 1) {
+            newSpeed = 0;
+        }
+        stack.stackTagCompound.setDouble(TAG_MODE_SPEED, newSpeed);
+        return newSpeed;
+    }
+
+    default double changeJump(ItemStack stack) {
+        if (stack.stackTagCompound == null) {
+            stack.setTagCompound(new NBTTagCompound());
+        }
+        // Internally MC returns 0 by default if the tag is not present, we do not need a presence check.
+        double oldJump = stack.stackTagCompound.getDouble(TAG_MODE_JUMP);
+        double newJump = oldJump + 0.1;
+        if (newJump > 1) {
+            newJump = 0;
+        }
+        stack.stackTagCompound.setDouble(TAG_MODE_JUMP, newJump);
+        return newJump;
+    }
+
+    default boolean toggleOmni(ItemStack stack) {
+        if (stack.stackTagCompound == null) {
+            stack.setTagCompound(new NBTTagCompound());
+        }
+        // Internally MC returns false by default if the tag is not present, we do not need a presence check.
+        boolean omni = stack.stackTagCompound.getBoolean(TAG_MOD_OMNI);
+        omni = !omni;
+        stack.stackTagCompound.setBoolean(TAG_MOD_OMNI, omni);
+        return omni;
+    }
+
+    default double getSpeedModifier(ItemStack stack) {
+        if (stack.stackTagCompound != null) {
+            return stack.stackTagCompound.getDouble(TAG_MODE_SPEED);
+        }
+        return 0;
+    }
+
+    default double getJumpModifier(ItemStack stack) {
+        if (stack.stackTagCompound != null) {
+            return stack.stackTagCompound.getDouble(TAG_MODE_JUMP);
+        }
+        return 0;
+    }
+
+    default boolean getOmniEnabled(ItemStack stack) {
+        if (stack.stackTagCompound != null) {
+            return stack.stackTagCompound.getBoolean(TAG_MOD_OMNI);
+        }
+        return false;
+    }
+
+    static ItemStack getBoots(EntityPlayer player) {
+        return player.getCurrentArmor(0);
+    }
+}

--- a/src/main/java/thaumicboots/api/ItemBoots.java
+++ b/src/main/java/thaumicboots/api/ItemBoots.java
@@ -29,7 +29,7 @@ import thaumcraft.common.Thaumcraft;
 import thaumcraft.common.items.armor.Hover;
 
 public class ItemBoots extends ItemArmor
-        implements ITBootJumpable, ITBootSpeed, IVisDiscountGear, IRunicArmor, IRepairable {
+        implements ITBootJumpable, ITBootSpeed, IVisDiscountGear, IRunicArmor, IRepairable, IBoots {
 
     public IIcon icon;
 
@@ -79,7 +79,7 @@ public class ItemBoots extends ItemArmor
     }
 
     public static double changeJump(double prevJump) {
-        double newJump = prevJump + 0.25;
+        double newJump = prevJump + 0.1;
         if (newJump > 1) {
             newJump = 0;
         }
@@ -105,7 +105,7 @@ public class ItemBoots extends ItemArmor
     }
 
     public static double changeSpeed(double prevSpeed) {
-        double newSpeed = prevSpeed + 0.25;
+        double newSpeed = prevSpeed + 0.1;
         if (newSpeed > 1) {
             newSpeed = 0;
         }
@@ -282,7 +282,7 @@ public class ItemBoots extends ItemArmor
         Minecraft mc = Minecraft.getMinecraft();
         String text = getModeText(
                 "thaumicboots.jumpEffect",
-                getBoots(mc.thePlayer).stackTagCompound.getDouble(TAG_MODE_JUMP) * 100);
+                IBoots.getBoots(mc.thePlayer).stackTagCompound.getDouble(TAG_MODE_JUMP) * 100);
         GTNHLib.proxy.printMessageAboveHotbar(text, 60, true, true);
     }
 
@@ -292,7 +292,7 @@ public class ItemBoots extends ItemArmor
         Minecraft mc = Minecraft.getMinecraft();
         String text = getModeText(
                 "thaumicboots.speedEffect",
-                getBoots(mc.thePlayer).stackTagCompound.getDouble(TAG_MODE_SPEED) * 100);
+                IBoots.getBoots(mc.thePlayer).stackTagCompound.getDouble(TAG_MODE_SPEED) * 100);
         GTNHLib.proxy.printMessageAboveHotbar(text, 60, true, true);
     }
 
@@ -300,9 +300,10 @@ public class ItemBoots extends ItemArmor
     @SideOnly(Side.CLIENT)
     public static void renderHUDOmniNotification() {
         Minecraft mc = Minecraft.getMinecraft();
-        String result = "thaumicboots.omniState" + getBoots(mc.thePlayer).stackTagCompound.getBoolean(TAG_MOD_OMNI);
+        String result = "thaumicboots.omniState"
+                + IBoots.getBoots(mc.thePlayer).stackTagCompound.getBoolean(TAG_MOD_OMNI);
         String midResult, finalResult;
-        if (getBoots(mc.thePlayer).stackTagCompound.getBoolean(TAG_MOD_OMNI)) {
+        if (IBoots.getBoots(mc.thePlayer).stackTagCompound.getBoolean(TAG_MOD_OMNI)) {
             midResult = EnumChatFormatting.DARK_GREEN + StatCollector.translateToLocal(result);
         } else {
             midResult = EnumChatFormatting.DARK_RED + StatCollector.translateToLocal(result);

--- a/src/main/java/thaumicboots/api/serverfiles/PacketJumpToggle.java
+++ b/src/main/java/thaumicboots/api/serverfiles/PacketJumpToggle.java
@@ -7,7 +7,7 @@ import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import io.netty.buffer.ByteBuf;
-import thaumicboots.api.ItemBoots;
+import thaumicboots.api.IBoots;
 
 public class PacketJumpToggle implements IMessage, IMessageHandler<PacketJumpToggle, IMessage> {
 
@@ -22,10 +22,9 @@ public class PacketJumpToggle implements IMessage, IMessageHandler<PacketJumpTog
     @Override
     public IMessage onMessage(PacketJumpToggle message, MessageContext ctx) {
         EntityPlayerMP player = ctx.getServerHandler().playerEntity;
-        final ItemStack boots = ItemBoots.getBoots(player);
-        if (boots != null) {
-            double jumpState = ItemBoots.changeJump(ItemBoots.isJumpEnabled(boots));
-            ItemBoots.setModeJump(boots, jumpState);
+        final ItemStack boots = IBoots.getBoots(player);
+        if (boots.getItem() instanceof IBoots item) {
+            double jumpState = item.changeJump(boots);
             PacketJumpToggleAck ackMessage = new PacketJumpToggleAck();
             ackMessage.state = jumpState;
             PacketHandler.INSTANCE.sendTo(ackMessage, player);

--- a/src/main/java/thaumicboots/api/serverfiles/PacketJumpToggleAck.java
+++ b/src/main/java/thaumicboots/api/serverfiles/PacketJumpToggleAck.java
@@ -9,6 +9,7 @@ import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
+import thaumicboots.api.IBoots;
 import thaumicboots.api.ItemBoots;
 import thaumicboots.main.utils.compat.GTNHLibHelper;
 
@@ -29,9 +30,9 @@ public class PacketJumpToggleAck implements IMessage, IMessageHandler<PacketJump
     @SideOnly(Side.CLIENT)
     public IMessage onMessage(PacketJumpToggleAck message, MessageContext ctx) {
         Minecraft mc = Minecraft.getMinecraft();
-        final ItemStack boots = ItemBoots.getBoots(mc.thePlayer);
-        if (boots != null) {
-            ItemBoots.setModeJump(boots, message.state);
+        final ItemStack boots = IBoots.getBoots(mc.thePlayer);
+        if (boots.getItem() instanceof IBoots item) {
+            item.setJumpModifier(boots, message.state);
             if (GTNHLibHelper.isActive()) {
                 ItemBoots.renderHUDJumpNotification();
             }

--- a/src/main/java/thaumicboots/api/serverfiles/PacketOmniToggle.java
+++ b/src/main/java/thaumicboots/api/serverfiles/PacketOmniToggle.java
@@ -7,7 +7,7 @@ import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import io.netty.buffer.ByteBuf;
-import thaumicboots.api.ItemBoots;
+import thaumicboots.api.IBoots;
 
 public class PacketOmniToggle implements IMessage, IMessageHandler<PacketOmniToggle, IMessage> {
 
@@ -22,10 +22,9 @@ public class PacketOmniToggle implements IMessage, IMessageHandler<PacketOmniTog
     @Override
     public IMessage onMessage(PacketOmniToggle message, MessageContext ctx) {
         EntityPlayerMP player = ctx.getServerHandler().playerEntity;
-        final ItemStack boots = ItemBoots.getBoots(player);
-        if (boots != null) {
-            boolean omniState = ItemBoots.changeOmniState(ItemBoots.isOmniEnabled(boots));
-            ItemBoots.setModeOmni(boots, omniState);
+        final ItemStack boots = IBoots.getBoots(player);
+        if (boots.getItem() instanceof IBoots item) {
+            boolean omniState = item.toggleOmni(boots);
             PacketOmniToggleAck ackMessage = new PacketOmniToggleAck();
             ackMessage.state = omniState;
             PacketHandler.INSTANCE.sendTo(ackMessage, player);

--- a/src/main/java/thaumicboots/api/serverfiles/PacketOmniToggleAck.java
+++ b/src/main/java/thaumicboots/api/serverfiles/PacketOmniToggleAck.java
@@ -9,6 +9,7 @@ import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
+import thaumicboots.api.IBoots;
 import thaumicboots.api.ItemBoots;
 import thaumicboots.main.utils.compat.GTNHLibHelper;
 
@@ -29,9 +30,9 @@ public class PacketOmniToggleAck implements IMessage, IMessageHandler<PacketOmni
     @SideOnly(Side.CLIENT)
     public IMessage onMessage(PacketOmniToggleAck message, MessageContext ctx) {
         Minecraft mc = Minecraft.getMinecraft();
-        final ItemStack boots = ItemBoots.getBoots(mc.thePlayer);
-        if (boots != null) {
-            ItemBoots.setModeOmni(boots, message.state);
+        final ItemStack boots = IBoots.getBoots(mc.thePlayer);
+        if (boots.getItem() instanceof IBoots item) {
+            item.setOmniEnabled(boots, message.state);
             if (GTNHLibHelper.isActive()) {
                 ItemBoots.renderHUDOmniNotification();
             }

--- a/src/main/java/thaumicboots/api/serverfiles/PacketSpeedToggle.java
+++ b/src/main/java/thaumicboots/api/serverfiles/PacketSpeedToggle.java
@@ -7,7 +7,7 @@ import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import io.netty.buffer.ByteBuf;
-import thaumicboots.api.ItemBoots;
+import thaumicboots.api.IBoots;
 
 public class PacketSpeedToggle implements IMessage, IMessageHandler<PacketSpeedToggle, IMessage> {
 
@@ -22,12 +22,11 @@ public class PacketSpeedToggle implements IMessage, IMessageHandler<PacketSpeedT
     @Override
     public IMessage onMessage(PacketSpeedToggle message, MessageContext ctx) {
         EntityPlayerMP player = ctx.getServerHandler().playerEntity;
-        final ItemStack boots = ItemBoots.getBoots(player);
-        if (boots != null) {
-            double jumpState = ItemBoots.changeSpeed(ItemBoots.isSpeedEnabled(boots));
-            ItemBoots.setModeSpeed(boots, jumpState);
+        final ItemStack boots = IBoots.getBoots(player);
+        if (boots.getItem() instanceof IBoots item) {
+            double speedState = item.changeSpeed(boots);
             PacketSpeedToggleAck ackMessage = new PacketSpeedToggleAck();
-            ackMessage.state = jumpState;
+            ackMessage.state = speedState;
             PacketHandler.INSTANCE.sendTo(ackMessage, player);
         }
         return null;

--- a/src/main/java/thaumicboots/api/serverfiles/PacketSpeedToggleAck.java
+++ b/src/main/java/thaumicboots/api/serverfiles/PacketSpeedToggleAck.java
@@ -9,6 +9,7 @@ import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
+import thaumicboots.api.IBoots;
 import thaumicboots.api.ItemBoots;
 import thaumicboots.main.utils.compat.GTNHLibHelper;
 
@@ -29,9 +30,9 @@ public class PacketSpeedToggleAck implements IMessage, IMessageHandler<PacketSpe
     @SideOnly(Side.CLIENT)
     public IMessage onMessage(PacketSpeedToggleAck message, MessageContext ctx) {
         Minecraft mc = Minecraft.getMinecraft();
-        final ItemStack boots = ItemBoots.getBoots(mc.thePlayer);
-        if (boots != null) {
-            ItemBoots.setModeSpeed(boots, message.state);
+        final ItemStack boots = IBoots.getBoots(mc.thePlayer);
+        if (boots.getItem() instanceof IBoots item) {
+            item.setSpeedModifier(boots, message.state);
             if (GTNHLibHelper.isActive()) {
                 ItemBoots.renderHUDSpeedNotification();
             }


### PR DESCRIPTION
### QOL Changes:
Changed boots speed/jump percentage change rate from 0.25 to 0.1 for better configurability.

### API Changes:
Added IBoots interface that is intended to be implemented by Item classes.
Speed, Jump, and Omni change packet handlers now call IBoots methods rather than the original ones.

### Justification
Boots implementing IBoots can have their speed boosts changed by the player, allowing for greater control.  Especially nice with EMT's quantum boots of the traveler which can be a little too fast in some cases and have unnecessarily high jump heights. See [EMT Pull Request](https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/75)