### PR TITLE
fix the typo

### DIFF
--- a/src/main/java/thaumicboots/main/utils/BootKeys.java
+++ b/src/main/java/thaumicboots/main/utils/BootKeys.java
@@ -26,7 +26,7 @@ public class BootKeys {
             Keyboard.KEY_NONE,
             "Thaumic Boots");
     private final KeyBinding keyOmniToggle = new KeyBinding(
-            "keybinding.omniToggle",
+            "keybinding.omnitoggle",
             Keyboard.KEY_NONE,
             "Thaumic Boots");
 

--- a/src/main/resources/assets/thaumicboots/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicboots/lang/en_US.lang
@@ -101,7 +101,7 @@ itemGroup.Thaumic Boots=Thaumic Boots
 
 keybinding.speedtoggle=Modulate Speed Boost
 keybinding.jumptoggle=Modulate Jump Boost
-keybinding.omnitoggle=Modulate Jump Boost
+keybinding.omnitoggle=Toggle Omnidirectional Movement
 
 thaumicboots.jumpEffect=Jump Boost:
 thaumicboots.speedEffect=Speed Boost:


### PR DESCRIPTION
fixes a typo that causes the omndirectional movement toggle to not have proper localization.