### PR TITLE
Fixed strafing issue with the boots introduced in 2.6.1

### DIFF
--- a/src/main/java/thaumicboots/api/ItemBoots.java
+++ b/src/main/java/thaumicboots/api/ItemBoots.java
@@ -179,10 +179,11 @@ public class ItemBoots extends ItemArmor
             bonus *= 0.25F;
         }
         if (player.onGround || player.isOnLadder() || player.capabilities.isFlying) {
+			if (player.moveForward != 0.0) {
+                player.moveFlying(0.0F, player.moveForward, bonus);
+            }
             if (player.moveStrafing != 0.0 && itemStack.stackTagCompound.getBoolean(TAG_MODE_OMNI)) {
                 player.moveFlying(player.moveStrafing, 0.0F, bonus);
-            } else if (player.moveForward != 0.0) {
-                player.moveFlying(0.0F, player.moveForward, bonus);
             }
         } else if (Hover.getHover(player.getEntityId())) {
             player.jumpMovementFactor = 0.03F;

--- a/src/main/java/thaumicboots/api/ItemBoots.java
+++ b/src/main/java/thaumicboots/api/ItemBoots.java
@@ -179,7 +179,7 @@ public class ItemBoots extends ItemArmor
             bonus *= 0.25F;
         }
         if (player.onGround || player.isOnLadder() || player.capabilities.isFlying) {
-			if (player.moveForward != 0.0) {
+            if (player.moveForward != 0.0) {
                 player.moveFlying(0.0F, player.moveForward, bonus);
             }
             if (player.moveStrafing != 0.0 && itemStack.stackTagCompound.getBoolean(TAG_MODE_OMNI)) {


### PR DESCRIPTION
This shouldn't have been made an else-if.

Resolves https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16344 and https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16337, although it looks like other people might be also encountering [bigger issues with the change](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16345) so it might just be worth reverting https://github.com/GTNewHorizons/ThaumicBoots/pull/27 entirely for now.