### PR TITLE
fixing the dependencies

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,8 +3,12 @@
 dependencies {
 	compile('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
 	compile('com.github.GTNewHorizons:Baubles:1.0.4:dev')
-	compile('com.github.GTNewHorizons:Thaumic_Exploration:1.3.0-GTNH:dev')
-	compile('com.github.GTNewHorizons:Electro-Magic-Tools:1.5.2:dev')
+	compile('com.github.GTNewHorizons:Thaumic_Exploration:1.3.1-GTNH:dev'){
+		exclude group: 'com.github.GTNewHorizons', module: 'thaumicboots'
+	}
+	compile('com.github.GTNewHorizons:Electro-Magic-Tools:1.5.3:dev'){
+		exclude group: 'com.github.GTNewHorizons', module: 'thaumicboots'
+	}
 	compile('com.github.GTNewHorizons:Tainted-Magic:7.6.8-GTNH')
 	compile('com.github.GTNewHorizons:GTNHLib:0.2.11')
 

--- a/src/main/java/thaumicboots/api/IBoots.java
+++ b/src/main/java/thaumicboots/api/IBoots.java
@@ -94,8 +94,7 @@ public interface IBoots {
             stack.setTagCompound(new NBTTagCompound());
         }
         // Internally MC returns false by default if the tag is not present, we do not need a presence check.
-        boolean inertiaCanceling = stack.stackTagCompound.getBoolean(TAG_MODE_INERTIA);
-        inertiaCanceling = !inertiaCanceling;
+        boolean inertiaCanceling = !(stack.stackTagCompound.getBoolean(TAG_MODE_INERTIA));
         stack.stackTagCompound.setBoolean(TAG_MODE_INERTIA, inertiaCanceling);
         return inertiaCanceling;
     }


### PR DESCRIPTION
When the original optional dep was added to EMT and Explorations, we forgot to add circular dependency protection to Thaumic Boots despite the fact we added it to EMT and Explorations