### PR TITLE
Update the Charging machine and max charge for the QVoidBoots + recipe fix

### DIFF
--- a/src/main/java/thaumicboots/item/boots/voidwalker/ItemElectricVoidwalkerBoots.java
+++ b/src/main/java/thaumicboots/item/boots/voidwalker/ItemElectricVoidwalkerBoots.java
@@ -33,7 +33,7 @@ public class ItemElectricVoidwalkerBoots extends ItemElectricBoots implements IW
     protected void setBootsData() {
         super.setBootsData();
         maxCharge = 100_000;
-        energyPerDamage = 500; // allows for 2k hits 2x more than base electric (for this mod)
+        energyPerDamage = 100; // allows for 2k hits 2x more than base electric (for this mod)
         runicCharge = 0;
         visDiscount = 5 + 2; // voidwalker + electric discount
         provideEnergy = false;

--- a/src/main/java/thaumicboots/item/boots/voidwalker/ItemElectricVoidwalkerBoots.java
+++ b/src/main/java/thaumicboots/item/boots/voidwalker/ItemElectricVoidwalkerBoots.java
@@ -32,7 +32,7 @@ public class ItemElectricVoidwalkerBoots extends ItemElectricBoots implements IW
 
     protected void setBootsData() {
         super.setBootsData();
-        maxCharge = 1_000_000;
+        maxCharge = 100_000;
         energyPerDamage = 500; // allows for 2k hits 2x more than base electric (for this mod)
         runicCharge = 0;
         visDiscount = 5 + 2; // voidwalker + electric discount

--- a/src/main/java/thaumicboots/item/boots/voidwalker/ItemNanoVoidwalkerBoots.java
+++ b/src/main/java/thaumicboots/item/boots/voidwalker/ItemNanoVoidwalkerBoots.java
@@ -9,7 +9,7 @@ public class ItemNanoVoidwalkerBoots extends ItemElectricVoidwalkerBoots {
     protected void setBootsData() {
         super.setBootsData();
         maxCharge = 1_000_000;
-        energyPerDamage = 2_500; // allows for 4k hits 2x more than base nano, 2x more than prev (for this mod)
+        energyPerDamage = 500; // allows for 4k hits 2x more than base nano, 2x more than prev (for this mod)
         visDiscount = 5 + 4; // voidwalker + nano discount
         damageAbsorptionRatio = 2.75D;
         transferLimit = 2_400;

--- a/src/main/java/thaumicboots/item/boots/voidwalker/ItemNanoVoidwalkerBoots.java
+++ b/src/main/java/thaumicboots/item/boots/voidwalker/ItemNanoVoidwalkerBoots.java
@@ -8,7 +8,7 @@ public class ItemNanoVoidwalkerBoots extends ItemElectricVoidwalkerBoots {
 
     protected void setBootsData() {
         super.setBootsData();
-        maxCharge = 10_000_000;
+        maxCharge = 1_000_000;
         energyPerDamage = 2_500; // allows for 4k hits 2x more than base nano, 2x more than prev (for this mod)
         visDiscount = 5 + 4; // voidwalker + nano discount
         damageAbsorptionRatio = 2.75D;

--- a/src/main/java/thaumicboots/item/boots/voidwalker/ItemQuantumVoidwalkerBoots.java
+++ b/src/main/java/thaumicboots/item/boots/voidwalker/ItemQuantumVoidwalkerBoots.java
@@ -9,7 +9,7 @@ public class ItemQuantumVoidwalkerBoots extends ItemElectricVoidwalkerBoots {
     protected void setBootsData() {
         super.setBootsData();
         maxCharge = 10_000_000;
-        energyPerDamage = 12_500; // allows for 8k hits 2x more than base quantum, 2x more than prev (for this mod)
+        energyPerDamage = 2_500; // allows for 8k hits 2x more than base quantum, 2x more than prev (for this mod)
         visDiscount = 5 + 5; // voidwalker + quantum discount
         damageAbsorptionRatio = 3.0D;
         transferLimit = 24_000;

--- a/src/main/java/thaumicboots/item/boots/voidwalker/ItemQuantumVoidwalkerBoots.java
+++ b/src/main/java/thaumicboots/item/boots/voidwalker/ItemQuantumVoidwalkerBoots.java
@@ -8,13 +8,15 @@ public class ItemQuantumVoidwalkerBoots extends ItemElectricVoidwalkerBoots {
 
     protected void setBootsData() {
         super.setBootsData();
-        maxCharge = 100_000_000;
+        maxCharge = 10_000_000;
         energyPerDamage = 12_500; // allows for 8k hits 2x more than base quantum, 2x more than prev (for this mod)
         visDiscount = 5 + 5; // voidwalker + quantum discount
         damageAbsorptionRatio = 3.0D;
         transferLimit = 24_000;
         jumpBonus = 1.0175D; // 11 blocks
         runBonus = 1.250F;
+
+        tier = 4;
         iconResPath = "thaumicboots:quantumVoid_16x";
         armorResPath = "thaumicboots:model/quantumbootsVoidwalker.png";
         unlocalisedName = "ItemQuantumVoid";

--- a/src/main/java/thaumicboots/main/utils/compat/EMTHelper.java
+++ b/src/main/java/thaumicboots/main/utils/compat/EMTHelper.java
@@ -120,7 +120,7 @@ public class EMTHelper implements IModHelper {
         if (ExplorationsHelper.isActive()) {
             electricComet = ThaumcraftApi.addInfusionCraftingRecipe(
                     "TB_Explorations_EMT_Compat",
-                    new ItemStack(EMTHelper.bootsElectricComet, 1, OreDictionary.WILDCARD_VALUE),
+                    new ItemStack(EMTHelper.bootsElectricComet, 1, 0),
                     0,
                     new AspectList().add(Aspect.EXCHANGE, 75).add(Aspect.MAGIC, 50).add(Aspect.CRAFT, 50)
                             .add(TB_Aspect.SPACE, 25).add(TB_Aspect.BOOTS, 25),
@@ -148,7 +148,7 @@ public class EMTHelper implements IModHelper {
 
             nanoComet = ThaumcraftApi.addInfusionCraftingRecipe(
                     "TB_Explorations_EMT_Compat",
-                    new ItemStack(EMTHelper.bootsNanoComet, 1, OreDictionary.WILDCARD_VALUE),
+                    new ItemStack(EMTHelper.bootsNanoComet, 1, 0),
                     0,
                     new AspectList().add(Aspect.EXCHANGE, 75).add(Aspect.MAGIC, 50).add(Aspect.CRAFT, 50)
                             .add(TB_Aspect.SPACE, 25).add(TB_Aspect.BOOTS, 25),
@@ -176,7 +176,7 @@ public class EMTHelper implements IModHelper {
 
             quantumComet = ThaumcraftApi.addInfusionCraftingRecipe(
                     "TB_Explorations_EMT_Compat",
-                    new ItemStack(EMTHelper.bootsQuantumComet, 1, OreDictionary.WILDCARD_VALUE),
+                    new ItemStack(EMTHelper.bootsQuantumComet, 1, 0),
                     0,
                     new AspectList().add(Aspect.EXCHANGE, 75).add(Aspect.MAGIC, 50).add(Aspect.CRAFT, 50)
                             .add(TB_Aspect.SPACE, 25).add(TB_Aspect.BOOTS, 25),
@@ -204,7 +204,7 @@ public class EMTHelper implements IModHelper {
 
             electricMeteor = ThaumcraftApi.addInfusionCraftingRecipe(
                     "TB_Explorations_EMT_Compat",
-                    new ItemStack(EMTHelper.bootsElectricMeteor, 1, OreDictionary.WILDCARD_VALUE),
+                    new ItemStack(EMTHelper.bootsElectricMeteor, 1, 0),
                     0,
                     new AspectList().add(Aspect.EXCHANGE, 75).add(Aspect.MAGIC, 50).add(Aspect.CRAFT, 50)
                             .add(TB_Aspect.SPACE, 25).add(TB_Aspect.BOOTS, 25),
@@ -232,7 +232,7 @@ public class EMTHelper implements IModHelper {
 
             nanoMeteor = ThaumcraftApi.addInfusionCraftingRecipe(
                     "TB_Explorations_EMT_Compat",
-                    new ItemStack(EMTHelper.bootsNanoMeteor, 1, OreDictionary.WILDCARD_VALUE),
+                    new ItemStack(EMTHelper.bootsNanoMeteor, 1, 0),
                     0,
                     new AspectList().add(Aspect.EXCHANGE, 75).add(Aspect.MAGIC, 50).add(Aspect.CRAFT, 50)
                             .add(TB_Aspect.SPACE, 25).add(TB_Aspect.BOOTS, 25),
@@ -260,7 +260,7 @@ public class EMTHelper implements IModHelper {
 
             quantumMeteor = ThaumcraftApi.addInfusionCraftingRecipe(
                     "TB_Explorations_EMT_Compat",
-                    new ItemStack(EMTHelper.bootsQuantumMeteor, 1, OreDictionary.WILDCARD_VALUE),
+                    new ItemStack(EMTHelper.bootsQuantumMeteor, 1, 0),
                     0,
                     new AspectList().add(Aspect.EXCHANGE, 75).add(Aspect.MAGIC, 50).add(Aspect.CRAFT, 50)
                             .add(TB_Aspect.SPACE, 25).add(TB_Aspect.BOOTS, 25),
@@ -290,7 +290,7 @@ public class EMTHelper implements IModHelper {
         if (TaintedHelper.isActive()) {
             electricVoid = ThaumcraftApi.addInfusionCraftingRecipe(
                     "TB_EMT_Tainted_Compat",
-                    new ItemStack(EMTHelper.bootsElectricVoid, 1, OreDictionary.WILDCARD_VALUE),
+                    new ItemStack(EMTHelper.bootsElectricVoid, 1, 0),
                     0,
                     new AspectList().add(Aspect.EXCHANGE, 75).add(Aspect.MAGIC, 50).add(Aspect.CRAFT, 50)
                             .add(TB_Aspect.SPACE, 25).add(TB_Aspect.BOOTS, 25),
@@ -318,7 +318,7 @@ public class EMTHelper implements IModHelper {
 
             nanoVoid = ThaumcraftApi.addInfusionCraftingRecipe(
                     "TB_EMT_Tainted_Compat",
-                    new ItemStack(EMTHelper.bootsNanoVoid, 1, OreDictionary.WILDCARD_VALUE),
+                    new ItemStack(EMTHelper.bootsNanoVoid, 1, 0),
                     0,
                     new AspectList().add(Aspect.EXCHANGE, 75).add(Aspect.MAGIC, 50).add(Aspect.CRAFT, 50)
                             .add(TB_Aspect.SPACE, 25).add(TB_Aspect.BOOTS, 25),
@@ -346,7 +346,7 @@ public class EMTHelper implements IModHelper {
 
             quantumVoid = ThaumcraftApi.addInfusionCraftingRecipe(
                     "TB_EMT_Tainted_Compat",
-                    new ItemStack(EMTHelper.bootsQuantumVoid, 1, OreDictionary.WILDCARD_VALUE),
+                    new ItemStack(EMTHelper.bootsQuantumVoid, 1, 0),
                     0,
                     new AspectList().add(Aspect.EXCHANGE, 75).add(Aspect.MAGIC, 50).add(Aspect.CRAFT, 50)
                             .add(TB_Aspect.SPACE, 25).add(TB_Aspect.BOOTS, 25),


### PR DESCRIPTION
I set it to tier 4 (EV) with a max charge of 10 M EU (The same as all other Quantum Stuff).

So now you can actually charge the blasted things in less than 6 months.

fixes [#17682](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17682) - at least according to my testing.