### PR TITLE
Small refactor, add in support for the nanochestplate for thaumic boots

### DIFF
--- a/src/main/java/thaumicboots/api/ItemBoots.java
+++ b/src/main/java/thaumicboots/api/ItemBoots.java
@@ -126,7 +126,20 @@ public class ItemBoots extends ItemArmor
 
     protected float computeBonus(ItemStack itemStack, EntityPlayer player) {
         int ticks = player.inventory.armorItemInSlot(0).stackTagCompound.getInteger("runTicks");
-        return runBonus + ((ticks * 0.2F) * longrunningbonus);
+        return speedBonus + ((ticks * 0.2F) * longrunningbonus);
+    }
+
+    protected boolean checkNanoChestplate(EntityPlayer player) {
+        // This method checks if the player is wearing the Advanced Nanochestplate and if it's in hover and fly mode.
+        ItemStack armor = player.inventory.armorItemInSlot(2);
+        if (armor != null && armor.getItem() != null
+                && armor.getItem().getUnlocalizedName().endsWith("advNanoChestPlate")) {
+            NBTTagCompound nbttagcompound = armor.getTagCompound();
+            boolean fly = nbttagcompound.getBoolean("isFlyActive");
+            boolean hover = nbttagcompound.getBoolean("isHoverActive");
+            return fly && hover;
+        }
+        return false;
     }
 
     @Override
@@ -136,7 +149,8 @@ public class ItemBoots extends ItemArmor
         }
 
         if (Config.allowInertiaCancelingFeature && isInertiaCanceled(itemStack)) {
-            if (player.moveForward == 0 && player.moveStrafing == 0 && player.capabilities.isFlying) {
+            if (player.moveForward == 0 && player.moveStrafing == 0
+                    && (player.capabilities.isFlying || checkNanoChestplate(player))) {
                 player.motionX *= 0.5;
                 player.motionZ *= 0.5;
             }
@@ -186,7 +200,7 @@ public class ItemBoots extends ItemArmor
         if (waterEffects && player.isInWater()) {
             bonus *= 0.25F;
         }
-        if (player.onGround || player.isOnLadder() || player.capabilities.isFlying) {
+        if (player.onGround || player.isOnLadder() || player.capabilities.isFlying || checkNanoChestplate(player)) {
             if (player.moveForward != 0.0) {
                 player.moveFlying(0.0F, player.moveForward, bonus);
             }

--- a/src/main/java/thaumicboots/api/ItemBoots.java
+++ b/src/main/java/thaumicboots/api/ItemBoots.java
@@ -30,7 +30,7 @@ public class ItemBoots extends ItemArmor
 
     public IIcon icon;
 
-    public float runBonus;
+    public float speedBonus;
     public float longrunningbonus;
     public int visDiscount;
     public int runicCharge;
@@ -53,7 +53,7 @@ public class ItemBoots extends ItemArmor
     protected void setBootsData() {
         runicCharge = 0;
         visDiscount = 0;
-        runBonus = 0.165F;
+        speedBonus = 0.165F;
         jumpBonus = 0.0D;
         omniMovement = false;
         tier = 0;
@@ -71,7 +71,7 @@ public class ItemBoots extends ItemArmor
     }
 
     public float getSpeedModifier() {
-        return runBonus;
+        return speedBonus;
     }
 
     // TODO: the part not from interfaces

--- a/src/main/java/thaumicboots/api/ItemElectricBoots.java
+++ b/src/main/java/thaumicboots/api/ItemElectricBoots.java
@@ -88,7 +88,7 @@ public class ItemElectricBoots extends ItemBoots implements IElectricItem, ISpec
     protected float computeBonus(ItemStack itemStack, EntityPlayer player) {
         int ticks = player.inventory.armorItemInSlot(0).stackTagCompound.getInteger("runTicks");
 
-        float bonus = runBonus + ((ticks / 5) * 0.003F);
+        float bonus = speedBonus + ((ticks / 5) * 0.003F);
         if (ElectricItem.manager.getCharge(itemStack) == 0) {
             bonus = 0;
         } else if (player.isInWater()) {

--- a/src/main/java/thaumicboots/item/boots/comet/ItemElectricCometBoots.java
+++ b/src/main/java/thaumicboots/item/boots/comet/ItemElectricCometBoots.java
@@ -20,7 +20,7 @@ public class ItemElectricCometBoots extends ItemElectricBoots implements IComet 
         energyPerDamage = 100; // 1k hits
         visDiscount = 2;
         transferLimit = 100;
-        runBonus = 0.165F; // electric + comet
+        speedBonus = 0.165F; // electric + comet
         jumpBonus = 0.275D; // 3 blocks
         longrunningbonus = 0.003F;
         minimumHeight = 4F;

--- a/src/main/java/thaumicboots/item/boots/comet/ItemNanoCometBoots.java
+++ b/src/main/java/thaumicboots/item/boots/comet/ItemNanoCometBoots.java
@@ -13,7 +13,7 @@ public class ItemNanoCometBoots extends ItemElectricCometBoots {
         energyPerDamage = 500; // 2k hits, 2x prev
         visDiscount = 4;
         transferLimit = 1_600;
-        runBonus = getEMTNanoSpeed() + 0.110F; // nano + comet * 2
+        speedBonus = getEMTNanoSpeed() + 0.110F; // nano + comet * 2
         jumpBonus = 0.6325D; // 6 blocks
         minimumHeight = 6F;
         minimumDistance = 35.0F;

--- a/src/main/java/thaumicboots/item/boots/comet/ItemQuantumCometBoots.java
+++ b/src/main/java/thaumicboots/item/boots/comet/ItemQuantumCometBoots.java
@@ -13,7 +13,7 @@ public class ItemQuantumCometBoots extends ItemElectricCometBoots {
         energyPerDamage = 2_500; // 4k hits, 2x prev
         visDiscount = 5;
         transferLimit = 12_000;
-        runBonus = getEMTQuantumSpeed() + 0.220F; // quantum + comet * 4
+        speedBonus = getEMTQuantumSpeed() + 0.220F; // quantum + comet * 4
         jumpBonus = 0.9075D; // 9.5 blocks
         minimumDistance = 100.0F;
         minimumHeight = 10F;

--- a/src/main/java/thaumicboots/item/boots/meteor/ItemElectricMeteorBoots.java
+++ b/src/main/java/thaumicboots/item/boots/meteor/ItemElectricMeteorBoots.java
@@ -17,7 +17,7 @@ public class ItemElectricMeteorBoots extends ItemElectricBoots implements IMeteo
         damageAbsorptionRatio = 1.25D;
         transferLimit = 100;
         jumpBonus = 0.5225D; // 5 blocks
-        runBonus = 0.055F; // base electric
+        speedBonus = 0.055F; // base electric
         tier = 2;
         negateFall = true;
         iconResPath = "thaumicboots:electricMeteor_16x";

--- a/src/main/java/thaumicboots/item/boots/meteor/ItemNanoMeteorBoots.java
+++ b/src/main/java/thaumicboots/item/boots/meteor/ItemNanoMeteorBoots.java
@@ -14,7 +14,7 @@ public class ItemNanoMeteorBoots extends ItemElectricMeteorBoots {
         damageAbsorptionRatio = 1.5D;
         transferLimit = 1600;
         jumpBonus = 0.7975D; // 8 Blocks
-        runBonus = getEMTNanoSpeed();
+        speedBonus = getEMTNanoSpeed();
         tier = 3;
         iconResPath = "thaumicboots:nanoMeteor_16x";
         armorResPath = "thaumicboots:model/nanobootsMeteor.png";

--- a/src/main/java/thaumicboots/item/boots/meteor/ItemQuantumMeteorBoots.java
+++ b/src/main/java/thaumicboots/item/boots/meteor/ItemQuantumMeteorBoots.java
@@ -17,7 +17,7 @@ public class ItemQuantumMeteorBoots extends ItemElectricMeteorBoots implements I
         damageAbsorptionRatio = 2D;
         transferLimit = 12000;
         jumpBonus = 1.1D; // 12 Blocks
-        runBonus = getEMTQuantumSpeed();
+        speedBonus = getEMTQuantumSpeed();
         tier = 4;
         iconResPath = "thaumicboots:quantumMeteor_16x";
         armorResPath = "thaumicboots:model/quantumbootsMeteor.png";

--- a/src/main/java/thaumicboots/item/boots/unique/ItemChristmasBoots.java
+++ b/src/main/java/thaumicboots/item/boots/unique/ItemChristmasBoots.java
@@ -25,7 +25,7 @@ public class ItemChristmasBoots extends ItemBoots implements IComet {
         }
         jumpBonus = 0.35D; // 3.5 blocks
         tier = 2;
-        runBonus = 0.165F;
+        speedBonus = 0.165F;
         longrunningbonus = 0.012F * modifier;
         steadyBonus = true;
         negateFall = true;

--- a/src/main/java/thaumicboots/item/boots/unique/ItemCometMeteorBoots.java
+++ b/src/main/java/thaumicboots/item/boots/unique/ItemCometMeteorBoots.java
@@ -20,7 +20,7 @@ public class ItemCometMeteorBoots extends ItemBoots implements ICometMeteorMix {
         super.setBootsData();
         jumpBonus = 0.35D; // 3.5 blocks
         tier = 2;
-        runBonus = 0.165F;
+        speedBonus = 0.165F;
         longrunningbonus = 0.003F;
         steadyBonus = true;
         negateFall = true;

--- a/src/main/java/thaumicboots/item/boots/unique/ItemSeasonBoots.java
+++ b/src/main/java/thaumicboots/item/boots/unique/ItemSeasonBoots.java
@@ -18,7 +18,7 @@ public class ItemSeasonBoots extends ItemBoots {
         super.setBootsData();
         jumpBonus = 0.35D; // 3.5 blocks
         tier = 2;
-        runBonus = 0.165F;
+        speedBonus = 0.165F;
         steadyBonus = true;
         negateFall = true;
         waterEffects = true;

--- a/src/main/java/thaumicboots/item/boots/unique/ItemSlowBoots.java
+++ b/src/main/java/thaumicboots/item/boots/unique/ItemSlowBoots.java
@@ -14,7 +14,7 @@ public class ItemSlowBoots extends ItemBoots {
     protected void setBootsData() {
         super.setBootsData();
         tier = 2;
-        runBonus = -0.035F;
+        speedBonus = -0.035F;
         negateFall = true;
         unlocalisedName = "ItemSlowBoots";
         iconResPath = "thaumicboots:bootsSlow_16x";

--- a/src/main/java/thaumicboots/item/boots/voidwalker/ItemCometVoidwalkerBoots.java
+++ b/src/main/java/thaumicboots/item/boots/voidwalker/ItemCometVoidwalkerBoots.java
@@ -14,7 +14,7 @@ public class ItemCometVoidwalkerBoots extends ItemVoidBoots implements IComet {
         visDiscount = 5;
         jumpBonus = 0.450D; // 4.5 blocks
         tier = 3;
-        runBonus = 0.215F * 3;
+        speedBonus = 0.215F * 3;
         iconResPath = "thaumicboots:voidComet_16x";
         armorResPath = "thaumicboots:model/VoidwalkerBootsComet_-_Purple.png";
         unlocalisedName = "ItemVoidComet";

--- a/src/main/java/thaumicboots/item/boots/voidwalker/ItemElectricVoidwalkerBoots.java
+++ b/src/main/java/thaumicboots/item/boots/voidwalker/ItemElectricVoidwalkerBoots.java
@@ -40,7 +40,7 @@ public class ItemElectricVoidwalkerBoots extends ItemElectricBoots implements IW
         damageAbsorptionRatio = 2.25D;
         transferLimit = 400;
         jumpBonus = 0.4675D; // 4.5 blocks
-        runBonus = 0.200F;
+        speedBonus = 0.200F;
 
         tier = 3;
         iconResPath = "thaumicboots:electricVoid_16x";
@@ -85,7 +85,7 @@ public class ItemElectricVoidwalkerBoots extends ItemElectricBoots implements IW
             }
 
             // speed boost
-            if (player.onGround || player.capabilities.isFlying) {
+            if (player.onGround || player.capabilities.isFlying || checkNanoChestplate(player)) {
                 float bonus = 0.200F;
                 final ItemStack sash = PlayerHandler.getPlayerBaubles(player).getStackInSlot(3);
                 if (sash != null && sash.getItem() == ItemRegistry.ItemVoidwalkerSash) {
@@ -95,7 +95,7 @@ public class ItemElectricVoidwalkerBoots extends ItemElectricBoots implements IW
                     bonus *= 0;
                 }
 
-                bonus = player.capabilities.isFlying ? bonus * 0.75F : bonus;
+                bonus = player.capabilities.isFlying || checkNanoChestplate(player) ? bonus * 0.75F : bonus;
                 bonus *= stack.stackTagCompound.getDouble(TAG_MODE_SPEED);
                 player.moveFlying(0.0F, 1.0F, bonus);
             } else if (Hover.getHover(player.getEntityId())) {

--- a/src/main/java/thaumicboots/item/boots/voidwalker/ItemMeteorVoidwalkerBoots.java
+++ b/src/main/java/thaumicboots/item/boots/voidwalker/ItemMeteorVoidwalkerBoots.java
@@ -14,7 +14,7 @@ public class ItemMeteorVoidwalkerBoots extends ItemVoidBoots implements IMeteor 
         visDiscount = 5;
         jumpBonus = 0.88D; // 9 blocks
         tier = 3;
-        runBonus = 0.300F;
+        speedBonus = 0.300F;
         iconResPath = "thaumicboots:purpleHaze_16x";
         armorResPath = "thaumicboots:model/VoidwalkerBootsMeteor_-_Purple.png";
         unlocalisedName = "ItemVoidMeteor";

--- a/src/main/java/thaumicboots/item/boots/voidwalker/ItemNanoVoidwalkerBoots.java
+++ b/src/main/java/thaumicboots/item/boots/voidwalker/ItemNanoVoidwalkerBoots.java
@@ -14,7 +14,7 @@ public class ItemNanoVoidwalkerBoots extends ItemElectricVoidwalkerBoots {
         damageAbsorptionRatio = 2.75D;
         transferLimit = 2_400;
         jumpBonus = 0.7425D; // 7.5 blocks
-        runBonus = 0.550F;
+        speedBonus = 0.550F;
         iconResPath = "thaumicboots:nanoVoid_16x";
         armorResPath = "thaumicboots:model/nanobootsVoidwalker.png";
         unlocalisedName = "ItemNanoVoid";

--- a/src/main/java/thaumicboots/item/boots/voidwalker/ItemQuantumVoidwalkerBoots.java
+++ b/src/main/java/thaumicboots/item/boots/voidwalker/ItemQuantumVoidwalkerBoots.java
@@ -14,7 +14,7 @@ public class ItemQuantumVoidwalkerBoots extends ItemElectricVoidwalkerBoots {
         damageAbsorptionRatio = 3.0D;
         transferLimit = 24_000;
         jumpBonus = 1.0175D; // 11 blocks
-        runBonus = 1.250F;
+        speedBonus = 1.250F;
 
         tier = 4;
         iconResPath = "thaumicboots:quantumVoid_16x";


### PR DESCRIPTION
Rename `runBonus` to `speedBonus` as that is more accurate since it affects creative flight speed.
Add in a check for the advanced Nanochestplate from GraviSuite so that it is supported, too.
It checks if the chest armor of the player is that specific part and if its in fly and hover mode.
Reason for that:
EMT Boots do work with the advanced Nanochestplate. Since f.ex. the Voidwalker boots are a direct upgrade from the EMT Boots it feels wrong for them to lose that ability in the process. Now Thaumic Boots behave the same as the EMT Boots in that regard.
This also fixes inertia cancelling with these boots.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17831
