### PR TITLE
Omni mode vertical flight boost

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,7 +11,7 @@ dependencies {
         exclude group: 'com.github.GTNewHorizons', module: 'ThaumicBoots'
         exclude module: 'Baubles'
     }
-    api('com.github.GTNewHorizons:Tainted-Magic:7.6.19-GTNH'){transitive = false}
+    api('com.github.GTNewHorizons:Tainted-Magic:7.6.23-GTNH'){transitive = false}
     api('com.github.GTNewHorizons:GTNHLib:0.6.36')
     compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.377:dev'){
 		exclude group: 'com.github.GTNewHorizons', module: 'ThaumicBoots'

--- a/src/main/java/thaumicboots/api/ItemBoots.java
+++ b/src/main/java/thaumicboots/api/ItemBoots.java
@@ -248,7 +248,6 @@ public class ItemBoots extends ItemArmor
                     } else if (jumping && !sneaking) {
                         player.motionY += bonus;
                     }
-                    }
                 }
             }
         } else if (Hover.getHover(player.getEntityId())) {

--- a/src/main/java/thaumicboots/api/ItemBoots.java
+++ b/src/main/java/thaumicboots/api/ItemBoots.java
@@ -165,7 +165,7 @@ public class ItemBoots extends ItemArmor
         if (player.moveForward <= 0F && !omniMode) {
             return;
         }
-        if ((player.moveForward == 0F && player.moveStrafing == 0F && player.motionY == 0F)) {
+        if (player.moveForward == 0F && player.moveStrafing == 0F && player.motionY == 0F) {
             return;
         }
 
@@ -236,7 +236,7 @@ public class ItemBoots extends ItemArmor
             if (player.moveForward != 0.0) {
                 player.moveFlying(0.0F, player.moveForward, bonus);
             }
-            if ( itemStack.stackTagCompound.getBoolean(TAG_MODE_OMNI)) {
+            if (itemStack.hasTagCompound() && itemStack.stackTagCompound.getBoolean(TAG_MODE_OMNI)) {
                 if (player.moveStrafing != 0.0) {
                     player.moveFlying(player.moveStrafing, 0.0F, bonus);
                 }

--- a/src/main/java/thaumicboots/api/ItemBoots.java
+++ b/src/main/java/thaumicboots/api/ItemBoots.java
@@ -2,7 +2,6 @@ package thaumicboots.api;
 
 import java.util.List;
 
-import baubles.common.lib.PlayerHandler;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
@@ -17,6 +16,7 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
+import baubles.common.lib.PlayerHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import taintedmagic.common.registry.ItemRegistry;
@@ -169,10 +169,10 @@ public class ItemBoots extends ItemArmor
             return;
         }
 
-        //step assist
+        // step assist
         stepHeight(player, itemStack);
 
-        //speed boost
+        // speed boost
         float bonus = getSpeedModifier();
         bonus += sashBuff(player);
 
@@ -194,7 +194,7 @@ public class ItemBoots extends ItemArmor
     public float sashBuff(final EntityPlayer player) {
         final ItemStack sash = PlayerHandler.getPlayerBaubles(player).getStackInSlot(3);
         if (sash != null && sash.getItem() == ItemRegistry.ItemVoidwalkerSash && sashHasSpeedBoost(sash)) {
-            return 0.4F; //sash speed buff
+            return 0.4F; // sash speed buff
         }
         return 0.0F;
     }

--- a/src/main/java/thaumicboots/api/ItemBoots.java
+++ b/src/main/java/thaumicboots/api/ItemBoots.java
@@ -243,14 +243,11 @@ public class ItemBoots extends ItemArmor
                 if (player.motionY != 0.0) {
                     boolean jumping = Minecraft.getMinecraft().gameSettings.keyBindJump.getIsKeyPressed();
                     boolean sneaking = player.isSneaking();
-                    float rise = Math.abs((float) player.motionY);
-                    if (sneaking && !jumping && !player.onGround) { //no moveFlying for vertical so this extracts the internals
-                        rise *= bonus / rise;
-                        player.motionY -= rise;
+                    if (sneaking && !jumping && !player.onGround) {
+                        player.motionY -= bonus;
+                    } else if (jumping && !sneaking) {
+                        player.motionY += bonus;
                     }
-                    if (!sneaking && jumping) {
-                        rise *= bonus / rise;
-                        player.motionY += rise;
                     }
                 }
             }

--- a/src/main/java/thaumicboots/api/ItemBoots.java
+++ b/src/main/java/thaumicboots/api/ItemBoots.java
@@ -193,10 +193,16 @@ public class ItemBoots extends ItemArmor
 
     public float sashBuff(final EntityPlayer player) {
         final ItemStack sash = PlayerHandler.getPlayerBaubles(player).getStackInSlot(3);
-        if (sash != null && sash.getItem() == ItemRegistry.ItemVoidwalkerSash) {
+        if (sash != null && sash.getItem() == ItemRegistry.ItemVoidwalkerSash && sashHasSpeedBoost(sash)) {
             return 0.4F; //sash speed buff
         }
         return 0.0F;
+    }
+
+    public boolean sashHasSpeedBoost(ItemStack s) {
+        if (s.stackTagCompound == null) return true;
+
+        else return s.stackTagCompound.getBoolean("mode");
     }
 
     public void stepHeight(EntityPlayer player, ItemStack itemStack) {

--- a/src/main/java/thaumicboots/api/ItemBoots.java
+++ b/src/main/java/thaumicboots/api/ItemBoots.java
@@ -175,7 +175,10 @@ public class ItemBoots extends ItemArmor
 
         // speed boost
         float bonus = getSpeedModifier();
-        bonus += sashBuffLocal(player);
+
+        if (TaintedHelper.isActive()) {
+            bonus += sashBuff(player);
+        }
 
         if (steadyBonus) {
             runningTicks(player);
@@ -190,13 +193,6 @@ public class ItemBoots extends ItemArmor
     public void applyFinalBonus(float bonus, EntityPlayer player, ItemStack itemStack) {
         bonus *= isSpeedEnabled(itemStack);
         applyBonus(player, bonus, itemStack);
-    }
-
-    private float sashBuffLocal(final EntityPlayer player) {
-        if (TaintedHelper.isActive()) {
-            return sashBuff(player);
-        }
-        return 0.0F;
     }
 
     public void stepHeight(EntityPlayer player, ItemStack itemStack) {

--- a/src/main/java/thaumicboots/api/ItemBoots.java
+++ b/src/main/java/thaumicboots/api/ItemBoots.java
@@ -1,5 +1,7 @@
 package thaumicboots.api;
 
+import static taintedmagic.common.items.equipment.ItemVoidwalkerBoots.sashBuff;
+
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
@@ -26,7 +28,6 @@ import thaumcraft.common.Thaumcraft;
 import thaumcraft.common.items.armor.Hover;
 import thaumicboots.main.Config;
 import thaumicboots.main.utils.compat.TaintedHelper;
-import static taintedmagic.common.items.equipment.ItemVoidwalkerBoots.sashBuff;
 
 public class ItemBoots extends ItemArmor
         implements ITBootJumpable, ITBootSpeed, IVisDiscountGear, IRunicArmor, IRepairable, IBoots {
@@ -197,7 +198,6 @@ public class ItemBoots extends ItemArmor
         }
         return 0.0F;
     }
-
 
     public void stepHeight(EntityPlayer player, ItemStack itemStack) {
         if (!player.worldObj.isRemote) {

--- a/src/main/java/thaumicboots/api/ItemBoots.java
+++ b/src/main/java/thaumicboots/api/ItemBoots.java
@@ -16,10 +16,8 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
-import baubles.common.lib.PlayerHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import taintedmagic.common.registry.ItemRegistry;
 import thaumcraft.api.IRepairable;
 import thaumcraft.api.IRunicArmor;
 import thaumcraft.api.IVisDiscountGear;
@@ -27,6 +25,8 @@ import thaumcraft.api.aspects.Aspect;
 import thaumcraft.common.Thaumcraft;
 import thaumcraft.common.items.armor.Hover;
 import thaumicboots.main.Config;
+import thaumicboots.main.utils.compat.TaintedHelper;
+import static taintedmagic.common.items.equipment.ItemVoidwalkerBoots.sashBuff;
 
 public class ItemBoots extends ItemArmor
         implements ITBootJumpable, ITBootSpeed, IVisDiscountGear, IRunicArmor, IRepairable, IBoots {
@@ -174,7 +174,7 @@ public class ItemBoots extends ItemArmor
 
         // speed boost
         float bonus = getSpeedModifier();
-        bonus += sashBuff(player);
+        bonus += sashBuffLocal(player);
 
         if (steadyBonus) {
             runningTicks(player);
@@ -191,19 +191,13 @@ public class ItemBoots extends ItemArmor
         applyBonus(player, bonus, itemStack);
     }
 
-    public float sashBuff(final EntityPlayer player) {
-        final ItemStack sash = PlayerHandler.getPlayerBaubles(player).getStackInSlot(3);
-        if (sash != null && sash.getItem() == ItemRegistry.ItemVoidwalkerSash && sashHasSpeedBoost(sash)) {
-            return 0.4F; // sash speed buff
+    private float sashBuffLocal(final EntityPlayer player) {
+        if (TaintedHelper.isActive()) {
+            return sashBuff(player);
         }
         return 0.0F;
     }
 
-    public boolean sashHasSpeedBoost(ItemStack s) {
-        if (s.stackTagCompound == null) return true;
-
-        else return s.stackTagCompound.getBoolean("mode");
-    }
 
     public void stepHeight(EntityPlayer player, ItemStack itemStack) {
         if (!player.worldObj.isRemote) {

--- a/src/main/java/thaumicboots/api/ItemVoidBoots.java
+++ b/src/main/java/thaumicboots/api/ItemVoidBoots.java
@@ -1,5 +1,6 @@
 package thaumicboots.api;
 
+import cpw.mods.fml.common.Optional;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -11,12 +12,14 @@ import net.minecraftforge.common.ISpecialArmor;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import taintedmagic.api.IVoidwalker;
 import thaumcraft.api.IWarpingGear;
 import thaumcraft.client.fx.ParticleEngine;
 import thaumcraft.client.fx.particles.FXWispEG;
 import thaumicboots.main.utils.TabThaumicBoots;
 
-public class ItemVoidBoots extends ItemBoots implements IWarpingGear, ISpecialArmor {
+@Optional.Interface(iface = "taintedmagic.api.IVoidwalker", modid = "TaintedMagic")
+public class ItemVoidBoots extends ItemBoots implements IVoidwalker, IWarpingGear, ISpecialArmor {
 
     public ItemVoidBoots(ArmorMaterial par2EnumArmorMaterial, int par3, int par4) {
         super(par2EnumArmorMaterial, par3, par4);

--- a/src/main/java/thaumicboots/api/ItemVoidBoots.java
+++ b/src/main/java/thaumicboots/api/ItemVoidBoots.java
@@ -27,8 +27,10 @@ public class ItemVoidBoots extends ItemBoots implements IWarpingGear, ISpecialAr
     }
 
     protected void setBootsData() {
+        super.setBootsData();
         visDiscount = 5;
         jumpBonus = 0.450D;
+        negateFall = true;
         tier = 3;
         iconResPath = "thaumicboots:voidComet_16x";
         armorResPath = "thaumicboots:model/VoidwalkerBootsComet_-_Purple.png";
@@ -93,37 +95,11 @@ public class ItemVoidBoots extends ItemBoots implements IWarpingGear, ISpecialAr
             stack.damageItem(-1, player);
         }
 
-        // negate fall damage
-        if (player.fallDistance > 3.0F) {
-            player.fallDistance = 1.0F;
-        }
-
         // particles
         final double motion = Math.abs(player.motionX) + Math.abs(player.motionZ) + Math.abs(0.5 * player.motionY);
         if (world.isRemote && (motion > 0.1D || !player.onGround) && world.rand.nextInt(3) == 0) {
             particles(world, player);
         }
-
-        if (player.moveForward <= 0F) {
-            return;
-        }
-
-        if (!player.isSneaking()) {
-            stepHeight(player, stack);
-        }
-
-        // speed boost
-        float bonus = getSpeedModifier() * sashEquiped(player);
-        bonus *= stack.stackTagCompound.getDouble(TAG_MODE_SPEED);
-        applyBonus(player, bonus, stack);
-    }
-
-    public float sashEquiped(final EntityPlayer player) {
-        final ItemStack sash = PlayerHandler.getPlayerBaubles(player).getStackInSlot(3);
-        if (sash != null && sash.getItem() == ItemRegistry.ItemVoidwalkerSash) {
-            return 3.0F;
-        }
-        return 1.0F;
     }
 
     // particle effect from Tainted Magic

--- a/src/main/java/thaumicboots/api/ItemVoidBoots.java
+++ b/src/main/java/thaumicboots/api/ItemVoidBoots.java
@@ -9,10 +9,8 @@ import net.minecraft.util.DamageSource;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ISpecialArmor;
 
-import baubles.common.lib.PlayerHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import taintedmagic.common.registry.ItemRegistry;
 import thaumcraft.api.IWarpingGear;
 import thaumcraft.client.fx.ParticleEngine;
 import thaumcraft.client.fx.particles.FXWispEG;

--- a/src/main/java/thaumicboots/api/ItemVoidBoots.java
+++ b/src/main/java/thaumicboots/api/ItemVoidBoots.java
@@ -1,6 +1,5 @@
 package thaumicboots.api;
 
-import cpw.mods.fml.common.Optional;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -10,6 +9,7 @@ import net.minecraft.util.DamageSource;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ISpecialArmor;
 
+import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import taintedmagic.api.IVoidwalker;

--- a/src/main/java/thaumicboots/item/boots/voidwalker/ItemElectricVoidwalkerBoots.java
+++ b/src/main/java/thaumicboots/item/boots/voidwalker/ItemElectricVoidwalkerBoots.java
@@ -46,6 +46,7 @@ public class ItemElectricVoidwalkerBoots extends ItemElectricBoots
         transferLimit = 400;
         jumpBonus = 0.4675D; // 4.5 blocks
         speedBonus = 0.200F;
+        negateFall = true;
 
         tier = 3;
         iconResPath = "thaumicboots:electricVoid_16x";
@@ -78,40 +79,6 @@ public class ItemElectricVoidwalkerBoots extends ItemElectricBoots
         final double motion = Math.abs(player.motionX) + Math.abs(player.motionZ) + Math.abs(0.5 * player.motionY);
         if (world.isRemote && (motion > 0.1D || !player.onGround) && world.rand.nextInt(3) == 0) {
             particles(world, player);
-        }
-
-        if (player.moveForward > 0.0F) {
-            // increased step height
-            if (player.worldObj.isRemote && !player.isSneaking()) {
-                if (!Thaumcraft.instance.entityEventHandler.prevStep.containsKey(player.getEntityId())) {
-                    Thaumcraft.instance.entityEventHandler.prevStep.put(player.getEntityId(), player.stepHeight);
-                }
-                player.stepHeight = 1.0F;
-            }
-
-            // speed boost
-            if (player.onGround || player.capabilities.isFlying || checkNanoChestplate(player)) {
-                float bonus = 0.200F;
-                final ItemStack sash = PlayerHandler.getPlayerBaubles(player).getStackInSlot(3);
-                if (sash != null && sash.getItem() == ItemRegistry.ItemVoidwalkerSash) {
-                    bonus *= 3.0F;
-                }
-                if (ElectricItem.manager.getCharge(stack) == 0) {
-                    bonus *= 0;
-                }
-
-                bonus = player.capabilities.isFlying || checkNanoChestplate(player) ? bonus * 0.75F : bonus;
-                bonus *= stack.stackTagCompound.getDouble(TAG_MODE_SPEED);
-                player.moveFlying(0.0F, 1.0F, bonus);
-            } else if (Hover.getHover(player.getEntityId())) {
-                player.jumpMovementFactor = 0.03F;
-            } else {
-                player.jumpMovementFactor = player.isSprinting() ? 0.045F : 0.04F;
-            }
-        }
-        // negate fall damage
-        if (player.fallDistance > 3.0F) {
-            player.fallDistance = 1.0F;
         }
     }
 

--- a/src/main/java/thaumicboots/item/boots/voidwalker/ItemElectricVoidwalkerBoots.java
+++ b/src/main/java/thaumicboots/item/boots/voidwalker/ItemElectricVoidwalkerBoots.java
@@ -6,19 +6,14 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ISpecialArmor;
 
-import baubles.common.lib.PlayerHandler;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.hazards.Hazard;
 import gregtech.api.hazards.IHazardProtector;
-import ic2.api.item.ElectricItem;
-import taintedmagic.common.registry.ItemRegistry;
 import thaumcraft.api.IWarpingGear;
 import thaumcraft.client.fx.ParticleEngine;
 import thaumcraft.client.fx.particles.FXWispEG;
-import thaumcraft.common.Thaumcraft;
-import thaumcraft.common.items.armor.Hover;
 import thaumicboots.api.ItemElectricBoots;
 import thaumicboots.main.utils.TabThaumicBoots;
 

--- a/src/main/java/thaumicboots/item/boots/voidwalker/ItemElectricVoidwalkerBoots.java
+++ b/src/main/java/thaumicboots/item/boots/voidwalker/ItemElectricVoidwalkerBoots.java
@@ -18,8 +18,7 @@ import thaumcraft.client.fx.particles.FXWispEG;
 import thaumicboots.api.ItemElectricBoots;
 import thaumicboots.main.utils.TabThaumicBoots;
 
-@Optional.InterfaceList({
-        @Optional.Interface(iface = "taintedmagic.api.IVoidwalker", modid = "TaintedMagic"),
+@Optional.InterfaceList({ @Optional.Interface(iface = "taintedmagic.api.IVoidwalker", modid = "TaintedMagic"),
         @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtech_nh") })
 public class ItemElectricVoidwalkerBoots extends ItemElectricBoots
         implements IVoidwalker, IWarpingGear, ISpecialArmor, IHazardProtector {

--- a/src/main/java/thaumicboots/item/boots/voidwalker/ItemElectricVoidwalkerBoots.java
+++ b/src/main/java/thaumicboots/item/boots/voidwalker/ItemElectricVoidwalkerBoots.java
@@ -11,15 +11,18 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.hazards.Hazard;
 import gregtech.api.hazards.IHazardProtector;
+import taintedmagic.api.IVoidwalker;
 import thaumcraft.api.IWarpingGear;
 import thaumcraft.client.fx.ParticleEngine;
 import thaumcraft.client.fx.particles.FXWispEG;
 import thaumicboots.api.ItemElectricBoots;
 import thaumicboots.main.utils.TabThaumicBoots;
 
-@Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtech_nh")
+@Optional.InterfaceList({
+        @Optional.Interface(iface = "taintedmagic.api.IVoidwalker", modid = "TaintedMagic"),
+        @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtech_nh") })
 public class ItemElectricVoidwalkerBoots extends ItemElectricBoots
-        implements IWarpingGear, ISpecialArmor, IHazardProtector {
+        implements IVoidwalker, IWarpingGear, ISpecialArmor, IHazardProtector {
 
     public ItemElectricVoidwalkerBoots(final ArmorMaterial material, final int j, final int k) {
         super(material, j, k);


### PR DESCRIPTION
Makes ascent/descend faster based on the speed buff if omni-mode is enabled, and makes voidwalker sash provide a consistent non-scaling bonus that respects its own speed toggle.

Affects all thaumicboot boots (electric/nano/quantum voidwalkers, as well as the meteoric/comet/seasonal combos). 