### PR TITLE
Fix `Config.gtnhLibActive` using wrong config name

### DIFF
--- a/src/main/java/thaumicboots/main/Config.java
+++ b/src/main/java/thaumicboots/main/Config.java
@@ -100,7 +100,7 @@ public class Config {
         thaumcraftActive = configuration.get(CATEGORY_MODULES, "Thaumcraft", true).getBoolean();
 
         // Optional Modules
-        p = configuration.get(CATEGORY_MODULES, "Electro-Magic-Tools", true);
+        p = configuration.get(CATEGORY_MODULES, "GTNHLib", true);
         gtnhLibActive = p.getBoolean();
 
         p = configuration.get(CATEGORY_MODULES, "Tainted-Magic", true);


### PR DESCRIPTION
Renames (duplicate) "Electro-Magic-Tools" to "GTNHLib"