### PR TITLE
Nerfed seasonal boot discounts and unified Comet boot bonuses

### DIFF
--- a/src/main/java/thaumicboots/item/boots/comet/ItemNanoCometBoots.java
+++ b/src/main/java/thaumicboots/item/boots/comet/ItemNanoCometBoots.java
@@ -21,6 +21,7 @@ public class ItemNanoCometBoots extends ItemElectricCometBoots implements IHazar
         visDiscount = 4;
         transferLimit = 1_600;
         speedBonus = getEMTNanoSpeed() + 0.110F; // nano + comet * 2
+        longrunningbonus = 0.006F; // 2x base
         jumpBonus = 0.6325D; // 6 blocks
         minimumHeight = 6F;
         minimumDistance = 35.0F;

--- a/src/main/java/thaumicboots/item/boots/comet/ItemQuantumCometBoots.java
+++ b/src/main/java/thaumicboots/item/boots/comet/ItemQuantumCometBoots.java
@@ -21,6 +21,7 @@ public class ItemQuantumCometBoots extends ItemElectricCometBoots implements IHa
         visDiscount = 5;
         transferLimit = 12_000;
         speedBonus = getEMTQuantumSpeed() + 0.220F; // quantum + comet * 4
+        longrunningbonus = 0.009F; // 3x base
         jumpBonus = 0.9075D; // 9.5 blocks
         minimumDistance = 100.0F;
         minimumHeight = 10F;

--- a/src/main/java/thaumicboots/item/boots/unique/ItemChristmasBoots.java
+++ b/src/main/java/thaumicboots/item/boots/unique/ItemChristmasBoots.java
@@ -18,7 +18,7 @@ public class ItemChristmasBoots extends ItemBoots implements IComet {
     protected void setBootsData() {
         super.setBootsData();
         if (CalendarHelper.isChristmas()) {
-            visDiscount = 12;
+            visDiscount = 9;
             modifier = 25;
         } else {
             visDiscount = 2;

--- a/src/main/java/thaumicboots/item/boots/unique/ItemChristmasBoots.java
+++ b/src/main/java/thaumicboots/item/boots/unique/ItemChristmasBoots.java
@@ -18,7 +18,7 @@ public class ItemChristmasBoots extends ItemBoots implements IComet {
     protected void setBootsData() {
         super.setBootsData();
         if (CalendarHelper.isChristmas()) {
-            visDiscount = 25;
+            visDiscount = 12;
             modifier = 12;
         } else {
             visDiscount = 2;

--- a/src/main/java/thaumicboots/item/boots/unique/ItemChristmasBoots.java
+++ b/src/main/java/thaumicboots/item/boots/unique/ItemChristmasBoots.java
@@ -19,7 +19,7 @@ public class ItemChristmasBoots extends ItemBoots implements IComet {
         super.setBootsData();
         if (CalendarHelper.isChristmas()) {
             visDiscount = 12;
-            modifier = 12;
+            modifier = 25;
         } else {
             visDiscount = 2;
         }

--- a/src/main/java/thaumicboots/item/boots/unique/ItemChristmasBoots.java
+++ b/src/main/java/thaumicboots/item/boots/unique/ItemChristmasBoots.java
@@ -26,7 +26,7 @@ public class ItemChristmasBoots extends ItemBoots implements IComet {
         jumpBonus = 0.35D; // 3.5 blocks
         tier = 2;
         speedBonus = 0.165F;
-        longrunningbonus = 0.012F * modifier;
+        longrunningbonus = 0.003F * modifier;
         steadyBonus = true;
         negateFall = true;
         waterEffects = true;

--- a/src/main/java/thaumicboots/item/boots/unique/ItemSeasonBoots.java
+++ b/src/main/java/thaumicboots/item/boots/unique/ItemSeasonBoots.java
@@ -30,7 +30,7 @@ public class ItemSeasonBoots extends ItemBoots {
             iconResPath = "thaumicboots:bootsChristmas";
             armorResPath = "thaumicboots:model/boots_christmas.png";
             visDiscount = 6;
-            modifier = 6;
+            modifier = 12;
         }
         longrunningbonus = 0.003F * modifier;
     }

--- a/src/main/java/thaumicboots/item/boots/unique/ItemSeasonBoots.java
+++ b/src/main/java/thaumicboots/item/boots/unique/ItemSeasonBoots.java
@@ -29,8 +29,8 @@ public class ItemSeasonBoots extends ItemBoots {
         if (CalendarHelper.isChristmas()) {
             iconResPath = "thaumicboots:bootsChristmas";
             armorResPath = "thaumicboots:model/boots_christmas.png";
-            visDiscount = 12;
-            modifier = 12;
+            visDiscount = 6;
+            modifier = 6;
         }
         longrunningbonus = 0.003F * modifier;
     }


### PR DESCRIPTION
This PR nerfs the December bonus for vis  discount for the Christmas boots and the Season boots. The bonus doubles the  discount for the Season boots, and triples it for the Christmas boots. 6% for  seasonal, and 9% for Christmas. The non-December stats remain the same at 3% for seasonal and 2% for Christmas.

It also nerfs the comet speed bonus a bit to unify the base comet bonus on all related comet boots, giving the Nano and Quantum boots an actual increase in the comet bonus over the basic comet boots.

With this, the Christmas boots are at the same discount as the Nano Voidwalker boots during December.

I am open to feedback regarding the numbers ofc. Personally, I don't think even an easter egg item should be so good for thaum progression. Other boots only cap out at 10% discount until Draconic and Infinity. The other boots at 10% are Quantum Voidwalker, Horizontal Shield, and Wyvern.